### PR TITLE
Adding a "bindUser" method to create a HCI_CHANNEL_USER socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,53 @@ bluetoothHciSocket.on('error', function(error) {
 ## Examples
 
 See [examples folder](https://github.com/sandeepmistry/node-bluetooth-hci-socket/blob/master/examples) for code examples.
+
+
+## Using HCI_CHANNEL_USER
+
+To gain complete and exclusive control of the HCI device, gatt uses
+HCI_CHANNEL_USER (introduced in Linux v3.14) instead of HCI_CHANNEL_RAW.
+Those who must use an older kernel may patch in these [relevant commits
+from Marcel Holtmann](http://www.spinics.net/lists/linux-bluetooth/msg37345.html):
+
+    Bluetooth: Introduce new HCI socket channel for user operation
+    Bluetooth: Introduce user channel flag for HCI devices
+    Bluetooth: Refactor raw socket filter into more readable code
+
+Note that because gatt uses HCI_CHANNEL_USER, once gatt has opened the
+device no other program may access it.
+
+Before starting a gatt program, make sure that your BLE device is down:
+
+    sudo hciconfig
+    sudo hciconfig hci0 down  # or whatever hci device you want to use
+
+If you have BlueZ 5.14+ (or aren't sure), stop the built-in
+bluetooth server, which interferes with gatt, e.g.:
+
+    sudo service bluetooth stop
+
+Because gatt programs administer network devices, they must
+either be run as root, or be granted appropriate capabilities:
+
+    sudo <executable>
+    # OR
+    sudo setcap 'cap_net_raw,cap_net_admin=eip' <executable>
+    <executable>
+
+Usage: 
+
+```javascript
+bluetoothHciSocket.start();
+// Warning: don't call setFilter !
+// Bind in HCI_CHANNEL_USER mode !
+bluetoothHciSocket.bindUser();
+```
+
+### Example using HCI_CHANNEL_USER
+
+The examples/le-user-scan-test.js provides a LE scan using the HCI_CHANNEL_USER socket.
+
+### Note on using HCI_CHANNEL_USER
+
+In HCI_CHANNEL_USER, you gain complete control of the device, bypassing the BlueZ layer. *You will need to handle all bluetooth protocols by yourself.*

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ See [examples folder](https://github.com/sandeepmistry/node-bluetooth-hci-socket
 
 ## Using HCI_CHANNEL_USER
 
-To gain complete and exclusive control of the HCI device, gatt uses
+(Thanks to the https://github.com/paypal/gatt project for this feature !)
+
+To gain complete and exclusive control of the HCI device, you may use
 HCI_CHANNEL_USER (introduced in Linux v3.14) instead of HCI_CHANNEL_RAW.
 Those who must use an older kernel may patch in these [relevant commits
 from Marcel Holtmann](http://www.spinics.net/lists/linux-bluetooth/msg37345.html):
@@ -143,10 +145,10 @@ from Marcel Holtmann](http://www.spinics.net/lists/linux-bluetooth/msg37345.html
     Bluetooth: Introduce user channel flag for HCI devices
     Bluetooth: Refactor raw socket filter into more readable code
 
-Note that because gatt uses HCI_CHANNEL_USER, once gatt has opened the
-device no other program may access it.
+Note that using HCI_CHANNEL_USER, once a socket is opened,
+no other program may access the device.
 
-Before starting a gatt program, make sure that your BLE device is down:
+Before starting a program in this mode, make sure that your BLE device is down:
 
     sudo hciconfig
     sudo hciconfig hci0 down  # or whatever hci device you want to use
@@ -156,7 +158,7 @@ bluetooth server, which interferes with gatt, e.g.:
 
     sudo service bluetooth stop
 
-Because gatt programs administer network devices, they must
+Because using this mode administer network devices, programs must
 either be run as root, or be granted appropriate capabilities:
 
     sudo <executable>
@@ -170,7 +172,7 @@ Usage:
 bluetoothHciSocket.start();
 // Warning: don't call setFilter !
 // Bind in HCI_CHANNEL_USER mode !
-bluetoothHciSocket.bindUser();
+bluetoothHciSocket.bindUser([deviceId]); // optional deviceId (integer)
 ```
 
 ### Example using HCI_CHANNEL_USER

--- a/examples/le-user-scan-test.js
+++ b/examples/le-user-scan-test.js
@@ -1,0 +1,136 @@
+var BluetoothHciSocket = require('../index');
+
+var bluetoothHciSocket = new BluetoothHciSocket();
+
+bluetoothHciSocket.on('data', function(data) {
+  console.log('data: ' + data.toString('hex'));
+
+  if (data.readUInt8(0) === HCI_EVENT_PKT) {
+    if (data.readUInt8(1) === EVT_CMD_COMPLETE) {
+      if (data.readUInt16LE(4) === LE_SET_SCAN_PARAMETERS_CMD) {
+        if (data.readUInt8(6) === HCI_SUCCESS) {
+          console.log('LE Scan Parameters Set');
+        }
+      } else if (data.readUInt16LE(4) === LE_SET_SCAN_ENABLE_CMD) {
+        if (data.readUInt8(6) === HCI_SUCCESS) {
+          console.log('LE Scan Enable Set');
+        }
+      }
+    } else if (data.readUInt8(1) === EVT_LE_META_EVENT) {
+      if (data.readUInt8(3) === EVT_LE_ADVERTISING_REPORT) { // subevent
+        var gapAdvType = data.readUInt8(5);
+        var gapAddrType = data.readUInt8(6);
+        var gapAddr = data.slice(7, 13);
+
+        var eir = data.slice(14, data.length - 1);
+        var rssi = data.readInt8(data.length - 1);
+
+        console.log('LE Advertising Report');
+        console.log('\t' + ['ADV_IND', 'ADV_DIRECT_IND', 'ADV_SCAN_IND', 'ADV_NONCONN_IND', 'SCAN_RSP'][gapAdvType]);
+        console.log('\t' + ['PUBLIC', 'RANDOM'][gapAddrType]);
+        console.log('\t' + gapAddr.toString('hex').match(/.{1,2}/g).reverse().join(':'));
+        console.log('\t' + eir.toString('hex'));
+        console.log('\t' + rssi);
+      }
+    }
+  }
+});
+
+bluetoothHciSocket.on('error', function(error) {
+  // TODO: non-BLE adaptor
+
+  if (error.message === 'Operation not permitted') {
+    console.log('state = unauthorized');
+  } else if (error.message === 'Network is down') {
+    console.log('state = powered off');
+  } else {
+    console.error(error);
+  }
+});
+
+var HCI_COMMAND_PKT = 0x01;
+var HCI_ACLDATA_PKT = 0x02;
+var HCI_EVENT_PKT = 0x04;
+
+var EVT_CMD_COMPLETE = 0x0e;
+var EVT_CMD_STATUS = 0x0f;
+var EVT_LE_META_EVENT = 0x3e;
+
+var EVT_LE_ADVERTISING_REPORT = 0x02;
+
+var OGF_LE_CTL = 0x08;
+var OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
+var OCF_LE_SET_SCAN_ENABLE = 0x000c;
+
+
+var LE_SET_SCAN_PARAMETERS_CMD = OCF_LE_SET_SCAN_PARAMETERS | OGF_LE_CTL << 10;
+var LE_SET_SCAN_ENABLE_CMD = OCF_LE_SET_SCAN_ENABLE | OGF_LE_CTL << 10;
+
+var HCI_SUCCESS = 0;
+
+function setFilter() {
+  var filter = new Buffer(14);
+  var typeMask = (1 << HCI_EVENT_PKT);
+  var eventMask1 = (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
+  var eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
+  var opcode = 0;
+
+  filter.writeUInt32LE(typeMask, 0);
+  filter.writeUInt32LE(eventMask1, 4);
+  filter.writeUInt32LE(eventMask2, 8);
+  filter.writeUInt16LE(opcode, 12);
+
+  bluetoothHciSocket.setFilter(filter);
+}
+
+function setScanParameters() {
+  var cmd = new Buffer(11);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_SCAN_PARAMETERS_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x07, 3);
+
+  // data
+  cmd.writeUInt8(0x01, 4); // type: 0 -> passive, 1 -> active
+  cmd.writeUInt16LE(0x0010, 5); // internal, ms * 1.6
+  cmd.writeUInt16LE(0x0010, 7); // window, ms * 1.6
+  cmd.writeUInt8(0x00, 9); // own address type: 0 -> public, 1 -> random
+  cmd.writeUInt8(0x00, 10); // filter: 0 -> all event types
+
+  bluetoothHciSocket.write(cmd);
+}
+
+function setScanEnable(enabled, duplicates) {
+  var cmd = new Buffer(6);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_SCAN_ENABLE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x02, 3);
+
+  // data
+  cmd.writeUInt8(enabled ? 0x01 : 0x00, 4); // enable: 0 -> disabled, 1 -> enabled
+  cmd.writeUInt8(duplicates ? 0x01 : 0x00, 5); // duplicates: 0 -> no duplicates, 1 -> duplicates
+
+  bluetoothHciSocket.write(cmd);
+}
+
+bluetoothHciSocket.start();
+
+// Bind in HCI_CHANNEL_USER mode !
+bluetoothHciSocket.bindUser();
+
+// Enable scan
+setScanEnable(false, false);
+setScanParameters();
+setScanEnable(true, false);
+
+// Stop scan after 2s
+setTimeout(function() {
+   setScanEnable(false, false);
+}, 2000);

--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -195,6 +195,8 @@ void BluetoothHciSocket::bindUser() {
   a.hci_dev = 0;
   a.hci_channel = HCI_CHANNEL_USER;
 
+  this->_devId = a.hci_dev;
+
   bind(this->_socket, (struct sockaddr *) &a, sizeof(a));
 }
 

--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -16,8 +16,10 @@
 #define HCIGETDEVLIST _IOR('H', 210, int)
 #define HCIGETDEVINFO _IOR('H', 211, int)
 
-#define HCI_CHANNEL_RAW   0
-#define HCI_CHANNEL_CONTROL 3
+#define HCI_CHANNEL_RAW   	0
+#define HCI_CHANNEL_USER	1
+#define HCI_CHANNEL_MONITOR	2
+#define HCI_CHANNEL_CONTROL 	3
 
 #define HCI_DEV_NONE  0xffff
 
@@ -105,6 +107,7 @@ void BluetoothHciSocket::Init(v8::Handle<v8::Object> target) {
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "start", BluetoothHciSocket::Start);
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "bindRaw", BluetoothHciSocket::BindRaw);
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "bindControl", BluetoothHciSocket::BindControl);
+  NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "bindUser", BluetoothHciSocket::BindUser);
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "getAddressBytes", BluetoothHciSocket::GetAddressBytes);
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "isDevUp", BluetoothHciSocket::IsDevUp);
   NODE_SET_PROTOTYPE_METHOD(NanNew(s_ct), "setFilter", BluetoothHciSocket::SetFilter);
@@ -180,6 +183,17 @@ void BluetoothHciSocket::bindControl() {
   a.hci_family = AF_BLUETOOTH;
   a.hci_dev = HCI_DEV_NONE;
   a.hci_channel = HCI_CHANNEL_CONTROL;
+
+  bind(this->_socket, (struct sockaddr *) &a, sizeof(a));
+}
+
+void BluetoothHciSocket::bindUser() {
+  struct sockaddr_hci a;
+
+  memset(&a, 0, sizeof(a));
+  a.hci_family = AF_BLUETOOTH;
+  a.hci_dev = 0;
+  a.hci_channel = HCI_CHANNEL_USER;
 
   bind(this->_socket, (struct sockaddr *) &a, sizeof(a));
 }
@@ -322,6 +336,16 @@ NAN_METHOD(BluetoothHciSocket::BindControl) {
   BluetoothHciSocket* p = node::ObjectWrap::Unwrap<BluetoothHciSocket>(args.This());
 
   p->bindControl();
+
+  NanReturnValue (NanUndefined());
+}
+
+NAN_METHOD(BluetoothHciSocket::BindUser) {
+  NanScope();
+
+  BluetoothHciSocket* p = node::ObjectWrap::Unwrap<BluetoothHciSocket>(args.This());
+
+  p->bindUser();
 
   NanReturnValue (NanUndefined());
 }

--- a/src/BluetoothHciSocket.h
+++ b/src/BluetoothHciSocket.h
@@ -17,6 +17,7 @@ public:
   static NAN_METHOD(New);
   static NAN_METHOD(BindRaw);
   static NAN_METHOD(BindControl);
+  static NAN_METHOD(BindUser);
   static NAN_METHOD(GetAddressBytes);
   static NAN_METHOD(IsDevUp);
   static NAN_METHOD(SetFilter);
@@ -31,6 +32,7 @@ private:
   void start();
   void bindRaw(int* devId);
   void bindControl();
+  void bindUser();
   bdaddr_t getAddressBytes();
   bool isDevUp();
   void setFilter(char* data, int length);

--- a/src/BluetoothHciSocket.h
+++ b/src/BluetoothHciSocket.h
@@ -27,7 +27,7 @@ private:
   void start();
   void bindRaw(int* devId);
   void bindControl();
-  void bindUser();
+  void bindUser(int* devId);
   bool isDevUp();
   void setFilter(char* data, int length);
   void stop();


### PR DESCRIPTION
Hi @sandeepmistry ,

Here is a pull request which allows creating a HCI_CHANNEL_USER socket.

Refs : 
* http://www.spinics.net/lists/linux-bluetooth/msg37345.html
* https://github.com/paypal/gatt

This mode allow to completely bypass the BlueZ layer and gain a direct access to the device.
It's very useful for my use case, which consists in emulating a peripheral: I need to change the default behavior of BlueZ ( auto reconnections, auto service discovery after connection, etc... )