### PR TITLE
Update to NAN 2 (enables support for io.js 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "nan": "^1.8.4"
+    "nan": "^2.0.5"
   },
   "optionalDependencies": {
     "usb": "^1.0.6"

--- a/src/BluetoothHciSocket.h
+++ b/src/BluetoothHciSocket.h
@@ -8,7 +8,7 @@
 class BluetoothHciSocket : public node::ObjectWrap {
 
 public:
-  static void Init(v8::Handle<v8::Object> target);
+  static NAN_MODULE_INIT(Init);
 
   static NAN_METHOD(New);
   static NAN_METHOD(BindRaw);
@@ -40,11 +40,13 @@ private:
   static void PollCallback(uv_poll_t* handle, int status, int events);
 
 private:
-  v8::Persistent<v8::Object> This;
+  Nan::Persistent<v8::Object> This;
 
   int _socket;
   int _devId;
   uv_poll_t _pollHandle;
+
+  static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };
 
 #endif


### PR DESCRIPTION
Pretty straightforward - migrate to NAN 2.x.x in order to support io.js 3.x.x. NAN 2 comes with cleaner syntax, so a few methods did get simplified a bit in the process.