### PR TITLE
Fix a crash when reading a buffer too small

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -121,6 +121,10 @@ BluetoothHciSocket.prototype.onHciEventEndpointData = function(data) {
     data
   ]);
 
+  if (this._hciEventEndpointBuffer.length <= 1) {
+    return;
+  }
+
   // check if desired length
   if (this._hciEventEndpointBuffer.readUInt8(1) === (this._hciEventEndpointBuffer.length - 2)) {
     // fire event


### PR DESCRIPTION
The onHciEventEndpointData callback tries to read the second byte to
check if the entire buffer has been received even if only one byte of
data has been received, causing an uncaught exception.
Added a check to verify that the buffer is at least two byte long before
reading.