### PR TITLE
Add support for Android OS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'conditions': [
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="android"', {
           'sources': [
             'src/BluetoothHciSocket.cpp'
           ]

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var platform = os.platform();
 
 if (process.env.BLUETOOTH_HCI_SOCKET_FORCE_USB || platform === 'win32') {
   module.exports = require('./lib/usb.js');
-} else if (platform === 'linux') {
+} else if (platform === 'linux' || platform === 'android') {
   module.exports = require('./lib/native');
 } else {
   throw new Error('Unsupported platform');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/sandeepmistry/node-bluetooth-hci-socket",
   "os": [
     "linux",
+    "android",
     "win32"
   ],
   "dependencies": {


### PR DESCRIPTION
Add android to supported OSes, so that bluetooth-hci-socket can be
compiled for and used on Android too.

Signed-off-by: Robert Chiras <robert.chiras@intel.com>