### PR TITLE
Write buffering

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -16,6 +16,8 @@ function BluetoothHciSocket() {
 
   this._hciEventEndpointBuffer = new Buffer(0);
   this._aclDataInEndpointBuffer = new Buffer(0);
+  this._isWriting = false;
+  this._writeBuffer = [];
 }
 
 util.inherits(BluetoothHciSocket, events.EventEmitter);
@@ -112,17 +114,39 @@ BluetoothHciSocket.prototype.stop = function() {
 
 BluetoothHciSocket.prototype.write = function(data) {
   debug('write: ' + data.toString('hex'));
+  
+  if (this._isWriting)
+  {
+    debug('write was buffered');
+    this._writeBuffer.push(data);
+    return;
+  }
 
   if (this._mode === 'raw' || this._mode === 'user') {
+    // Lock writing until this write completes
+    this._isWriting = true;
     var type = data.readUInt8(0);
 
     if (HCI_COMMAND_PKT === type) {
-      this._usbDevice.controlTransfer(usb.LIBUSB_REQUEST_TYPE_CLASS | usb.LIBUSB_RECIPIENT_INTERFACE, 0, 0, 0, data.slice(1));
+      this._usbDevice.controlTransfer(usb.LIBUSB_REQUEST_TYPE_CLASS | usb.LIBUSB_RECIPIENT_INTERFACE, 0, 0, 0, data.slice(1), this.onWriteFinished.bind(this));
     } else if(HCI_ACLDATA_PKT === type) {
-      this._aclDataOutEndpoint.transfer(data.slice(1));
+      this._aclDataOutEndpoint.transfer(data.slice(1), this.onWriteFinished.bind(this));
     }
   }
 };
+
+BluetoothHciSocket.prototype.onWriteFinished = function(error, data) {
+  debug('write finished');
+  
+  // Reset our writing flag and call write again if we've buffered data
+  this._isWriting = false;
+  if (this._writeBuffer.length > 0)
+  {
+    debug('writing buffered data');
+    var dataToWrite = this._writeBuffer.shift();
+    this.write(dataToWrite);
+  }
+}
 
 BluetoothHciSocket.prototype.onHciEventEndpointData = function(data) {
   debug('HCI event: ' + data.toString('hex'));


### PR DESCRIPTION
In some scenarios we were allowing transfer to be called inside write
before transfer had fired it's callback. We now respect those callbacks
and buffer our data internally.