### PR TITLE
Add FreeBSD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/
+lib/binding/
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bluetooth HCI socket binding for Node.js
 
-__NOTE:__ Currently only supports __Linux__ and __Windows__.
+__NOTE:__ Currently only supports __Linux__, __FreeBSD__ and __Windows__.
 
 ## Prerequisites
 
@@ -166,6 +166,16 @@ Set ```BLUETOOTH_HCI_SOCKET_FORCE_USB``` environment variable:
 
 ```sh
 sudo BLUETOOTH_HCI_SOCKET_FORCE_USB=1 node <file>.js
+```
+
+### FreeBSD
+
+Disable automatic loading of the default Bluetooth stack by putting [no-ubt.conf](https://gist.github.com/myfreeweb/44f4f3e791a057bc4f3619a166a03b87) into ```/usr/local/etc/devd/no-ubt.conf``` and restarting devd (```sudo service devd restart```).
+
+Unload ```ng_ubt``` kernel module if already loaded:
+
+```sh
+sudo kldunload ng_ubt
 ```
 
 ### OS X

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'binding',
       'conditions': [
-        ['OS=="linux" or OS=="android"', {
+        ['OS=="linux" or OS=="android" or OS=="freebsd"', {
           'sources': [
             'src/BluetoothHciSocket.cpp'
           ]

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var os = require('os');
 
 var platform = os.platform();
 
-if (process.env.BLUETOOTH_HCI_SOCKET_FORCE_USB || platform === 'win32') {
+if (process.env.BLUETOOTH_HCI_SOCKET_FORCE_USB || platform === 'win32' || platform === 'freebsd') {
   module.exports = require('./lib/usb.js');
 } else if (platform === 'linux' || platform === 'android') {
   module.exports = require('./lib/native');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "os": [
     "linux",
     "android",
+    "freebsd",
     "win32"
   ],
   "dependencies": {


### PR DESCRIPTION
Depends on tessel/node-usb#154.

I've been able to discover my Pebble Time from my Raspberry Pi running FreeBSD using the example in `noble`! :) A `noble` PR is coming as well.


The LE discovery example here doesn't seem to actually discover anything though.

When testing to make sure the example fails on a Linux VM as well (and indeed it does), I also had to change:
```javascript
var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
```

to

```javascript
var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
```

in `lib/native.js`.