### PR TITLE
renamed module_name and target_name

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   'targets': [
     {
-      'target_name': 'binding',
+      'target_name': 'bluetooth_hci_socket',
       'conditions': [
         ['OS=="linux" or OS=="android" or OS=="freebsd"', {
           'sources': [

--- a/lib/native.js
+++ b/lib/native.js
@@ -1,9 +1,5 @@
 var events = require('events');
-
-var binary = require('node-pre-gyp');
-var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
-var binding = require(binding_path);
+var binding = require('bindings')('bluetooth_hci_socket.node');
 
 var BluetoothHciSocket = binding.BluetoothHciSocket;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bluetooth-hci-socket",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "description": "Bluetooth HCI socket binding for Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "win32"
   ],
   "dependencies": {
+    "bindings": "~1.3.0",
     "debug": "^2.2.0",
     "nan": "^2.0.5",
     "node-pre-gyp": "0.6.x"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "install": "node-pre-gyp install --fallback-to-build"
   },
   "binary": {
-      "module_name": "binding",
+      "module_name": "bluetooth_hci_socket",
       "module_path": "./lib/binding/",
       "host": "https://github.com/sandeepmistry/node-bluetooth-hci-socket/releases/download/",
       "package_name": "{module_name}-{version}-{node_abi}-{platform}-{arch}.tar.gz",


### PR DESCRIPTION
The idea is to make sure you don't use common names that could be used by other modules.
This becomes important when you use "host override" feature of node-pre-gyp