### PR TITLE
Add Intel 6235 chipset

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ __WARNING:__ This will make the adapter unavailable in Windows Bluetooth setting
 | BCM20702A0 Bluetooth 4.0 | 0x0489 | 0xe07a |
 | CSR8510 A10 | 0x0a12 | 0x0001 |
 | Asus BT-400 | 0x0b05 | 0x17cb |
+| Intel Wireless Bluetooth 6235 | 0x8087 | 0x07da |
 | Intel Wireless Bluetooth 7260 | 0x8087 | 0x07dc |
 | Intel Wireless Bluetooth 7265 | 0x8087 | 0x0a2a |
 | Belkin BCM20702A0 | 0x050D | 0x065A |

--- a/lib/usb.js
+++ b/lib/usb.js
@@ -69,6 +69,7 @@ BluetoothHciSocket.prototype.bindUser = function(devId) {
       usb.findByIds(0x19ff, 0x0239) || // Broadcom BCM20702A0
       usb.findByIds(0x0a12, 0x0001) || // CSR
       usb.findByIds(0x0b05, 0x17cb) || // ASUS BT400
+      usb.findByIds(0x8087, 0x07da) || // Intel 6235
       usb.findByIds(0x8087, 0x07dc) || // Intel 7260
       usb.findByIds(0x8087, 0x0a2a) || // Intel 7265
       usb.findByIds(0x0489, 0xe07a) || // Broadcom BCM20702A1


### PR DESCRIPTION
Bluetooth provided in Intel Centrino Advanced-N 6235 chipset.

Tested on ASUS UX32VC and noble.

Also fixes the #51 (although it was closed for inactivity)