### PR TITLE
Add Marvell AVASTAR adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ __WARNING:__ This will make the adapter unavailable in Windows Bluetooth setting
 | Name | USB VID | USB PID |
 |:---- | :------ | :-------|
 | BCM2045A0 Bluetooth 4.1 | 0x0a5c | 0x6412 |
+| Marvell AVASTAR | 0x1286 | 0x204C |
 
 ## Install
 

--- a/lib/usb.js
+++ b/lib/usb.js
@@ -75,7 +75,8 @@ BluetoothHciSocket.prototype.bindUser = function(devId) {
       usb.findByIds(0x8087, 0x0a2b) || // Intel 8265
       usb.findByIds(0x0489, 0xe07a) || // Broadcom BCM20702A1
       usb.findByIds(0x0a5c, 0x6412) || // Broadcom BCM2045A0
-      usb.findByIds(0x050D, 0x065A); // Belkin BCM20702A0
+      usb.findByIds(0x050D, 0x065A) || // Belkin BCM20702A0
+      usb.findByIds(0x1286, 0x204C); // Marvell AVASTAR
   }
 
   if (!this._usbDevice) {


### PR DESCRIPTION
Add Marvell AVASTAR Bluetooth Radio Adapter (Surface Book 2).

Apparently Marvell AVASTAR adapter requires also another change to work, as endpoints are not in the same address as other adapters have. Created an issue https://github.com/noble/node-bluetooth-hci-socket/issues/86.