### PR TITLE
usb: Add missing semicolon to comply es6

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -114,7 +114,7 @@ BluetoothHciSocket.prototype.getDeviceList = function() {
       "busNumber": dev.busNumber,
       "deviceAddress": dev.deviceAddress,
     }));
-}
+};
 
 BluetoothHciSocket.prototype.bindControl = function() {
   this._mode = 'control';


### PR DESCRIPTION
Change-Id: I94fdcbea6957d9f2c7eb5e28d8364363be6a3520
Signed-off-by: Philippe Coval <p.coval@samsung.com>