### PR TITLE
remove nodejs 4 because also EOL and node-gyp dep no longer support it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,17 +7,12 @@ environment:
   GYP_MSVS_VERSION: 2013
 
   matrix:
-    - node_version: '4'
     - node_version: '5'
     - node_version: '6'
 
 install:
   - ps: Install-Product node $env:node_version $env:platform
   - ps: npm install -g node-gyp node-pre-gyp-github
-  # This fixes an issue with Node 4.x on x86. If it builds without this line
-  # needing to be set, we can remove it.
-  - ps: npm config -g set node-gyp "$(npm config -g get prefix)\node_modules\node-gyp\bin\node-gyp.js"
-
   - ps: if ($env:appveyor_repo_tag -match "true" -and $env:appveyor_repo_tag_name -match '^v?[0-9]') { $publish_binary=1; }
 
 build_script:


### PR DESCRIPTION
Origin: https://github.com/abandonware/node-bluetooth-hci-socket/pull/2
Forwarded: https://github.com/noble/node-bluetooth-hci-socket/pull/104