### PR TITLE
fix(pids): add alt Qualcomm Atheros QCA61x4 pids

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -13,6 +13,8 @@ var OCF_RESET = 0x0003;
 
 var VENDOR_DEVICE_LIST = [
   {vid: 0x0CF3, pid: 0xE300 }, // Qualcomm Atheros QCA61x4
+  {vid: 0x0CF3, pid: 0xE301 }, // Qualcomm Atheros QCA61x4
+  {vid: 0x0CF3, pid: 0x3004 }, // Qualcomm Atheros QCA61x4
   {vid: 0x0a5c, pid: 0x21e8 }, // Broadcom BCM20702A0
   {vid: 0x19ff, pid: 0x0239 }, // Broadcom BCM20702A0
   {vid: 0x0a12, pid: 0x0001 }, // CSR


### PR DESCRIPTION
The Qualcomm Atheros Bluetooth Driver version 10.0.0.1016, v.10.0.0.953 for Windows 10 32-bit (x86), 64-bit (x64) install 
includes a string section in the atheros_bth.inf file attached. This defines additional pids for the Qualcomm Atheros QCA61x4, this change will add those to the supported vendor device list. I am now able to run examples/advertisement-discovery.js in the noble project.


```
[Strings]
ProviderName       = "Qualcomm"
ManufacturerName   = "Qualcomm"
SourceDisk         = "Qualcomm Atheros CD"

VID_0CF3&PID_E300  = "Qualcomm Atheros QCA61x4 Bluetooth"
VID_0CF3&PID_3004  = "Qualcomm Atheros QCA61x4 Bluetooth"
VID_0CF3&PID_E360  = "Qualcomm Atheros QCA9377 Bluetooth"
VID_0CF3&PID_E370  = "Qualcomm Atheros QCA9377 Bluetooth"
VID_0CF3&PID_E500  = "Qualcomm Atheros QCA9377 Bluetooth"
VID_0CF3&PID_E400  = "Qualcomm Atheros QCA6290 Bluetooth"
VID_0CF3&PID_E007  = "Qualcomm QCA61x4A Bluetooth"
VID_0CF3&PID_E301  = "Qualcomm Atheros QCA61x4 Bluetooth"
VID_0CF3&PID_E009  = "Qualcomm QCA9377 Bluetooth"
VID_0CF3&PID_E010  = "Qualcomm QCA6174A Bluetooth"
VID_0489&PID_E0A2  = "Qualcomm QCA61x4A Bluetooth"
VID_0CF3&PID_535B  = "Qualcomm QCA6174A Bluetooth"
```

[Bluetooth_Atheros_10.0.0.1016_W10.zip](https://github.com/noble/node-bluetooth-hci-socket/files/6794530/Bluetooth_Atheros_10.0.0.1016_W10.zip)
